### PR TITLE
added provider block and region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "ca-central-1" //Canada
+}
+
 resource "aws_instance" "web" {
   ami           = "ami-01e36b7901e884a10"
   instance_type = "t3.micro"


### PR DESCRIPTION
Without the provider block, accurics will not understand the target cloud provider and the region where 'accurics plan' is going to deploy the resources